### PR TITLE
Resolves player not properly collecting item reward

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -77,9 +77,17 @@ Event.register(defines.events.on_entity_died, function(event)
     if not (cause and cause.valid) then return end
 
     local player
+
     if cause.type == "car" then
         player = cause.get_driver()
+        if player then
+            if player.type == "character" then
+                player = player.player
+            end
+        end
     elseif cause.type == "player" then
+        player = cause.player
+    elseif cause.type == "character" then
         player = cause.player
     end
     if not (player and player.valid) then return end
@@ -99,7 +107,14 @@ Event.register(defines.events.on_entity_damaged, function(event)
     local player
     if cause.type == "car" then
         player = cause.get_driver()
+        if player then
+            if player.type == "character" then
+                player = player.player
+            end
+        end
     elseif cause.type == "player" then
+        player = cause.player
+    elseif cause.type == "character" then
         player = cause.player
     end
     if not (player and player.valid) then return end


### PR DESCRIPTION
Tested on factorio 0.17.79 steam build

Law below was not triggering when event was fired:

![image](https://user-images.githubusercontent.com/2522505/81515025-29df3b00-9300-11ea-9f90-fb67bec24a75.png)

![image](https://user-images.githubusercontent.com/2522505/81516000-76c51080-9304-11ea-868e-8f6061250d77.png)

The registered event handlers events.on_entity_damanged
and events.on_entity_died did not properly set the player attribute.

In those handlers the returned value from cause.get_driver() may be a LuaEntity or LuaPlayer:

get_driver() → LuaEntity or LuaPlayer

https://lua-api.factorio.com/latest/LuaEntity.html

When a law has an effect of EFFECT_REWARD_TYPE_ITEM, the player
attribute is expected to be type LuaPlayer.

This PR updates the two event handlers mentioned above to to handle when LuaEntity is returned by now checking the type attribute for the value of 'character' and assigns player attribute accordingly.



