### PR TITLE
Adds clause WHEN_PLAYER_RESPAWNS

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -224,6 +224,14 @@ Event.register(defines.events.on_player_driving_changed_state, function(event)
     end
 end)
 
+Event.register(defines.events.on_player_respawned, function(event)
+    local player = Event.get_player(event)
+    if not (player and player.valid) then return end
+    local laws = LawMatch(WHEN_PLAYER_RESPAWNS, message, player.force, player)
+    event.force = player.force
+    ExecuteLaws(laws, event)
+end)
+
 script.on_nth_tick(3, function(event)
     -- Remove items (queued up via law effects)
     for _, player in pairs(game.players) do -- TODO: change for connected players

--- a/locale/en/lawful-evil.cfg
+++ b/locale/en/lawful-evil.cfg
@@ -49,6 +49,7 @@ clause-type.player-crafts=a player crafts
 clause-type.player-tiles=a player tiles
 clause-type.player-mines-tiles=a player mines tiles
 clause-type.player-kills-player=a player kills a player
+clause-type.player-respawns=a player respawns
 clause-type.force-researches=research completes
 clause-type.rocket-launched=a rocket is launched
 clause-type.player-chats=a player chats

--- a/locale/ru/lawful-evil.cfg
+++ b/locale/ru/lawful-evil.cfg
@@ -51,6 +51,7 @@ clause-type.player-crafts=игрок крафтит
 clause-type.player-tiles=игрок плитку ставит
 clause-type.player-mines-tiles=игрок добывает плитку
 clause-type.player-kills-player=игрок убивает игрока
+# clause-type.player-respawns=
 clause-type.force-researches=исследование завершается
 clause-type.rocket-launched=ракета запущена
 clause-type.player-chats=игрок пишет сообщение

--- a/mod-defines.lua
+++ b/mod-defines.lua
@@ -9,6 +9,7 @@ WHEN_PLAYER_KILLS = "player-kills-player"
 WHEN_FORCE_RESEARCHES = "force-researches"
 WHEN_ROCKET_LAUNCHES = "rocket-launched"
 WHEN_PLAYER_CHATS = "player-chats"
+WHEN_PLAYER_RESPAWNS = "player-respawns"
 WHEN_THIS_LAW_PASSED = "this-law-passed"
 WHEN_VALUE = "value"
 WHEN_DAY = "daytime"
@@ -137,6 +138,13 @@ CLAUSE_TYPES = {
         and_allowed = true,
         or_allowed = true,
         order = "m"
+    },
+    [WHEN_PLAYER_RESPAWNS] = {
+        localised_text = "a player respawns",
+        base_allowed = true,
+        and_allowed = false,
+        or_allowed = true,
+        order = "n"
     },
 }
 


### PR DESCRIPTION
Adds clause WHEN_PLAYER_RESPAWNS

Allows laws to have clauses that trigger on defines.events.on_player_respawned

![image](https://user-images.githubusercontent.com/2522505/82705207-3ab77700-9c45-11ea-8ab7-ddcc962faa5b.png)
